### PR TITLE
Handle when no window or document (nodejs runtime)

### DIFF
--- a/src/supports.js
+++ b/src/supports.js
@@ -8,29 +8,32 @@ import camelCase from 'lodash/camelCase';
  * @returns {boolean}
  */
 const isSupported = (property, value) => {
-  // Try the native standard method first
-  if ('CSS' in window && 'supports' in window.CSS) {
-    return window.CSS.supports(property, value);
+  // Handle when running in NodeJS and not a browser
+  if (typeof window !== "undefined" && typeof document !== "undefined") {
+    // Try the native standard method first
+    if ('CSS' in window && 'supports' in window.CSS) {
+      return window.CSS.supports(property, value);
+    }
+
+    // Check Opera's native method
+    if ('supportsCSS' in window) {
+      return window.supportsCSS(property, value);
+    }
+
+    // Convert to camel-case for DOM interactions
+    const camelCaseProperty = camelCase(property);
+
+    // Check if the property is supported
+    const element = document.createElement('div');
+    const support = (camelCaseProperty in element.style);
+
+    // Assign the property and value to invoke the CSS interpreter
+    element.style.cssText = `${property}:${value}`;
+
+    // Ensure both the property and value are
+    // supported and return
+    return support && (element.style[camelCaseProperty] !== '');
   }
-
-  // Check Opera's native method
-  if ('supportsCSS' in window) {
-    return window.supportsCSS(property, value);
-  }
-
-  // Convert to camel-case for DOM interactions
-  const camelCaseProperty = camelCase(property);
-
-  // Check if the property is supported
-  const element = document.createElement('div');
-  const support = (camelCaseProperty in element.style);
-
-  // Assign the property and value to invoke the CSS interpreter
-  element.style.cssText = `${property}:${value}`;
-
-  // Ensure both the property and value are
-  // supported and return
-  return support && (element.style[camelCaseProperty] !== '');
 };
 
 export default isSupported;


### PR DESCRIPTION
Hello,

Unfortunately, as your package uses window and document which in the GatsbyJS world at build time doesn't exist as it's in Node and not in a browser its breaking builds.

This PR performs a simple check to make sure `window` and `document` actually exists before trying to use them.

Any questions let me know :)